### PR TITLE
Fixed bracket operator not working for steps within the pipeline.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
 ### Deprecated
 
 ### Fixed
+
   * Fixed pipeline crashing in RMSE module because of wrong time index ([#39](https://github.com/KIT-IAI/pyWATTS/issues/39))
+  * Fixed bracket operator not working for steps within the pipeline ([#42](https://github.com/KIT-IAI/pyWATTS/issues/42))
 
 
 ## [0.0.1] - 2021-MM-DD

--- a/pywatts/core/step_information.py
+++ b/pywatts/core/step_information.py
@@ -14,8 +14,8 @@ class StepInformation:
         self.pipeline = pipeline
 
     def __getitem__(self, item: str):
-        from pywatts.core.pipeline_step import PipelineStep
-        if isinstance(self.step, PipelineStep) or len(self.step.targets) > 1:
+        from pywatts.core.step import Step
+        if isinstance(self.step, Step):
             self.step.last = False  # TODO this should be a part of the step_factory
             result_step = self.step.get_result_step(item)
             id = self.pipeline.add(module=result_step, input_ids=[self.step.id])


### PR DESCRIPTION
Fixed bracket operator (`__getitem__(self, key)`) not working for steps withing pipeline because of a check of PipelineStep instead of Step. The issue was mentioned in #42.