### PR TITLE
Fixed missing data_vars error for dicts passed to pipelines.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@
 ### Deprecated
 
 ### Fixed
+
   * Fixed pipeline crashing in RMSE module because of wrong time index ([#39](https://github.com/KIT-IAI/pyWATTS/issues/39))
+  * Fixed dict objects could not be passed to pipeline ([#43](https://github.com/KIT-IAI/pyWATTS/issues/43))
 
 
 ## [0.0.1] - 2021-MM-DD


### PR DESCRIPTION
Because Dict objects have not data_vars object the pipeline crashing when passing Dicts as mentioned in #43.