### PR TITLE
Remove step.stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Add parameters to RMSECalculator so that it can caluclate a sliding rmse too. ([#23](https://github.com/KIT-IAI/pyWATTS/issues/28))
 
 ### Changed
-
+* Remove parameter step.stop. Instead we call the method _should_stop on the previous steps. ([#25](https://github.com/KIT-IAI/pyWATTS/issues/25))
 ### Deprecated
 
 ### Fixed

--- a/tests/unit/core/test_either_or_step.py
+++ b/tests/unit/core/test_either_or_step.py
@@ -9,12 +9,10 @@ import pandas as pd
 class TestEitherOrStep(unittest.TestCase):
     def setUp(self) -> None:
         self.step_one = MagicMock()
-        self.step_one.stop = True
         self.step_one.id = 1
         self.step_two = MagicMock()
         self.result_mock_step_2 = MagicMock()
         self.result_mock_step_1 = MagicMock()
-        self.step_two.stop = False
         time = pd.date_range('2000-01-01', freq='24H', periods=7)
 
         self.da2 = xr.DataArray([[2, 0], [3, 2], [4, 3], [5, 4], [6, 5], [7, 6], [8, 7]],

--- a/tests/unit/core/test_probabilistic_step.py
+++ b/tests/unit/core/test_probabilistic_step.py
@@ -13,7 +13,7 @@ class TestProbabilisticStep(unittest.TestCase):
         self.probabilistic_module = MagicMock()
         self.input_step = MagicMock()
         self.input_step.get_result.return_value = MagicMock(), False
-        self.input_step.stop = False
+        self.input_step._should_stop.return_value = False
         self.probabilistic_step = ProbablisticStep(self.probabilistic_module, {"x": self.input_step},
                                                    file_manager=MagicMock())
 
@@ -29,12 +29,12 @@ class TestProbabilisticStep(unittest.TestCase):
         self.probabilistic_module.predict_proba.assert_called_once_with(input_mock)
 
     def test_get_result_stop(self):
-        self.input_step.stop = True
+        self.input_step._should_stop.return_value = True
 
         self.probabilistic_step.get_result(pd.Timestamp("2000.01.01"), pd.Timestamp("2000.01.02"))
 
         self.probabilistic_module.predict_proba.assert_not_called()
-        self.assertTrue(self.probabilistic_step.stop)
+        self.assertTrue(self.probabilistic_step._should_stop(pd.Timestamp("2000.01.01"), pd.Timestamp("2000.01.02")))
 
     def test_transform_no_prob_method(self):
         self.probabilistic_module.has_predict_proba = False

--- a/tests/unit/core/test_step.py
+++ b/tests/unit/core/test_step.py
@@ -15,7 +15,6 @@ class TestStep(unittest.TestCase):
         self.module_mock = MagicMock()
         self.module_mock.name = "test"
         self.step_mock = MagicMock()
-        self.step_mock.stop = False
         self.step_mock.id = 2
 
     def tearDown(self) -> None:
@@ -105,7 +104,7 @@ class TestStep(unittest.TestCase):
     def test_transform_batch_with_existing_buffer(self, xr_mock, *args):
         # Check that data in batch learning are concatenated
         input_step = MagicMock()
-        input_step.stop = False
+        input_step._should_stop.return_value = False
         time = pd.date_range('2000-01-01', freq='1D', periods=7)
         time2 = pd.date_range('2000-01-14', freq='1D', periods=7)
         time3 = pd.date_range('2000-01-01', freq='1D', periods=14)
@@ -135,9 +134,9 @@ class TestStep(unittest.TestCase):
         # Tests if the get_result method calls correctly the previous step and the module
 
         input_step = MagicMock()
-        input_step.stop = False
         input_step_result_mock = MagicMock()
         input_step.get_result.return_value = input_step_result_mock
+        input_step._should_stop.return_value = False
 
         time = pd.date_range('2000-01-01', freq='1H', periods=7)
         self.module_mock.transform.return_value = xr.DataArray([2, 3, 4, 3, 3, 1, 2], dims=["time"],
@@ -263,11 +262,10 @@ class TestStep(unittest.TestCase):
         step = Step(MagicMock(), MagicMock(), MagicMock())
         step.buffer = MagicMock()
         step.computation_mode = ComputationMode.Transform
-        step.stop = True
         step.finished = True
         step.reset()
 
         self.assertIsNone(None)
         assert step.computation_mode == ComputationMode.Default
-        assert step.stop == False
+        assert step._should_stop(None, None) == False
         assert step.finished == False


### PR DESCRIPTION
Remove unncessary parameter stop from steps and adapt the corresponding tests.

## Description
In the new version (version 0.1) the parameter stop is uncessary. For checking it is sufficient to call _should_stop on the previous steps.
Therefore the parameter should be removed

## Related Issues
#25 
## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos)
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Did you update the CHANGELOG

## PR review
Anyone in the community is free to review the PR once the tests have passed.

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones to the PR so it can be classified
