### PR TITLE
Extract the time index from the correct input in rolling rmse.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 * Fix save and load of keras Wrapper  ([#91](https://github.com/KIT-IAI/pyWATTS/issues/91))
 * Import of pytorchWrapper via wrapper.__init__
 * Fix the mask for weekends and public holidays in rolling_base  ([#107](https://github.com/KIT-IAI/pyWATTS/issues/107))
+* Fix the extracted time index in rolling RMSE  ([#124](https://github.com/KIT-IAI/pyWATTS/issues/124))
 * Use raise from if an exception is raise because an other is raised before for retaining the original stack trace  ([#107](https://github.com/KIT-IAI/pyWATTS/issues/123))
 
 

--- a/pywatts/modules/rolling_metric_base.py
+++ b/pywatts/modules/rolling_metric_base.py
@@ -74,13 +74,13 @@ class RollingMetricBase(BaseTransformer, ABC):
         for key, y_hat in kwargs.items():
             p = y_hat.values
             p_, t_ = p.reshape((len(p), -1)), t.reshape((len(t), -1))
-            index = y.indexes[_get_time_indeces(kwargs)[0]]
+            index = y.indexes[_get_time_indeces(y)[0]]
             results[key] = self._apply_rolling_metric(p_, t_, index)
         time = y.indexes[_get_time_indeces(y)[0]]
 
         return xr.DataArray(np.concatenate(list(results.values()), axis=1),
-                            coords={"time": time, "predictions": list(results.keys())},
-                            dims=["time", "predictions"])
+                            coords={_get_time_indeces(y)[0]: time, "predictions": list(results.keys())},
+                            dims=[_get_time_indeces(y)[0], "predictions"])
 
     @abstractmethod
     def _apply_rolling_metric(self, p_, t_, index):

--- a/tests/unit/modules/test_rolling_rmse.py
+++ b/tests/unit/modules/test_rolling_rmse.py
@@ -1,13 +1,12 @@
 import unittest
 
+import numpy as np
+import pandas as pd
 import pytest
 import xarray as xr
-import pandas as pd
+
 from pywatts.core.exceptions.input_not_available import InputNotAvailable
 from pywatts.modules.rolling_rmse import RollingRMSE
-
-from pywatts.modules.root_mean_squared_error import RmseCalculator
-import numpy as np
 
 
 class TestRollingRMSE(unittest.TestCase):
@@ -34,9 +33,13 @@ class TestRollingRMSE(unittest.TestCase):
 
         test_data = xr.Dataset({"testCol": ("time", xr.DataArray([-2, -1, 0, 1, 2]).data),
                                 "predictCol1": ("time", xr.DataArray([2, -3, 3, 1, -2]).data),
-                                "predictCol2": ("time", xr.DataArray([4, 4, 3, -2, 1]).data), "time": time})
+                                "predictCol2": ("time", xr.DataArray([4, 4, 3, -2, 1]).data), "time": time, "timeTest": time})
 
-        test_result = self.rolling_rmse.transform(y=test_data['testCol'], gt=test_data['testCol'],
+        y = xr.DataArray(np.array([-2, -1, 0, 1, 2]),
+                                       coords={"timeTest": time},
+                                       dims=["timeTest"])
+
+        test_result = self.rolling_rmse.transform(y=y, gt=test_data['testCol'],
                                                   pred1=test_data['predictCol1'],
                                                   pred2=test_data['predictCol2'])
         expected_result = xr.DataArray(np.array([[0.0, 4, 6],
@@ -44,8 +47,8 @@ class TestRollingRMSE(unittest.TestCase):
                                                  [0.0, np.sqrt(6.5), np.sqrt(17)],
                                                  [0.0, np.sqrt(4.5), 3],
                                                  [0.0, np.sqrt(8), np.sqrt(5)], ]),
-                                       coords={"time": time, "predictions": ["gt", "pred1", "pred2"]},
-                                       dims=["time", "predictions"])
+                                       coords={"timeTest": time, "predictions": ["gt", "pred1", "pred2"]},
+                                       dims=["timeTest", "predictions"])
 
         xr.testing.assert_allclose(test_result, expected_result)
 


### PR DESCRIPTION
## Description
Extract the time index from y instead from kwargs in rolling rmse

## Related Issues
closes #124 

## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos)
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Did you update the CHANGELOG

## PR review
Anyone in the community is free to review the PR once the tests have passed.

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones to the PR so it can be classified
