### PR TITLE
Fixed wrong if statements in _run method of pipeline causing summary …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+### Changed
+
+### Deprecated
+
+### Fixed
+* Fixed wrong check of if summary should be returned in _run method of pipeline ([#157](https://github.com/KIT-IAI/pyWATTS/issues/157))
 
 ## 0.2.0 - 2021-30-09
 

--- a/pywatts/core/pipeline.py
+++ b/pywatts/core/pipeline.py
@@ -200,7 +200,7 @@ class Pipeline(BaseTransformer):
         if isinstance(data, xr.Dataset):
             result = self.transform(**{key: data[key] for key in data.data_vars})
             sum = self._create_summary(summary_formatter)
-            return (result, sum) if sum else result
+            return (result, sum) if summary else result
         elif isinstance(data, dict):
             for key in data:
                 if not isinstance(data[key], xr.DataArray):
@@ -211,7 +211,7 @@ class Pipeline(BaseTransformer):
                     )
             result = self.transform(**data)
             sum = self._create_summary(summary_formatter)
-            return (result, sum) if sum else result
+            return (result, sum) if summary else result
 
         raise WrongParameterException(
             "Unkown data type to pass to pipeline steps.",


### PR DESCRIPTION
## Description
In the `_run` method of the `Pipeline` class, the if statement is wrong when checking if summaries should be returned (`summary` should be checked instead of `sum`). Therefore, summary objects are always returned also when `summary=False` in `train(..)` or `test(..)`.

## Related Issues
#157 
 
## Before submitting
- [x] Was this discussed/approved via a GitHub issue? (not for typos)
- [x] Did you make sure your PR does only one thing, instead of bundling different changes together?
- [x] Did you make sure to update the documentation with your changes? (if necessary)
- [x] Did you write any new necessary tests? (not for typos and docs)
- [x] Did you verify new and existing tests pass locally with your changes?
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Did you update the CHANGELOG

## PR review
Anyone in the community is free to review the PR once the tests have passed.

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [x] Add labels and milestones to the PR so it can be classified
